### PR TITLE
adapt compRelSEM() call to semTools 0.5-8

### DIFF
--- a/R/silp.R
+++ b/R/silp.R
@@ -81,11 +81,15 @@ silp = function(model, data, center = "double", tau.eq = F, npd = F ,... ){
   
   
   #CFA model
-  MD = lavaan::cfa(str_c(o_eq, sep = "/n"), data,  bounds =  "pos.var")
-  Rel = semTools::compRelSEM(MD, tau.eq = tau.eq, return.df = T)
+  MD <- lavaan::cfa(str_c(o_eq, sep = "/n"), data,  bounds =  "pos.var")
+  ## Estimate reliability from CFA parameters.
+  ## Check which version of semTools is installed.
+  if (utils::packageDescription("semTools", fields = "Version") < "0.5-8") {
+    Rel <- semTools::compRelSEM(MD, tau.eq = tau.eq, return.df = T)
+  } else {
+    Rel <- semTools::compRelSEM(MD, tau.eq = tau.eq, simplify = -1L)
+  }
 
-  
-  
   #lv regression
   l_eq = eq[str_detect(eq, pattern = "~~") == FALSE &
               str_detect(eq, pattern = "=~") == FALSE]


### PR DESCRIPTION
I have made some changes to `semTools::compRelSEM()` that break your `resilp()` help-page example. This PR addresses that issue by conditionally calling `semTools::compRelSEM()` with the `return.df=` or `simplify=` argument, based on the user's installed version of semTools. 

Could you please send a new version to CRAN as soon as you can? I cannot send the semTools update to CRAN until this is resolved.